### PR TITLE
fix bug preventing editing and deleting the todo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,8 +159,15 @@ function App() {
                         type="text"
                         value={editTodo}
                         onChange={handleChange}
+                        onClick={e => e.stopPropagation()}
                       />
-                      <button type="button" onClick={() => handleEdit(td.id)}>
+                      <button
+                        type="button"
+                        onClick={e => {
+                          e.stopPropagation();
+                          handleEdit(td.id);
+                        }}
+                      >
                         Update
                       </button>
                     </>
@@ -169,7 +176,10 @@ function App() {
                       {td.todo}
                       <button
                         type="button"
-                        onClick={() => openEdit(td.id, td.todo)}
+                        onClick={e => {
+                          e.stopPropagation();
+                          openEdit(td.id, td.todo);
+                        }}
                       >
                         <svg
                           width="1rem"
@@ -213,7 +223,13 @@ function App() {
                           </g>
                         </svg>
                       </button>
-                      <button type="button" onClick={() => handleDelete(td.id)}>
+                      <button
+                        type="button"
+                        onClick={e => {
+                          e.stopPropagation();
+                          handleDelete(td.id);
+                        }}
+                      >
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           xmlnsXlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
Added: 

event.stopPropagation() to the onClick handlers for:
- The Update Button
- The Update editing input
- The Delete button

the stopPropagation event method prevents the click event from bubbling up from the buttons (and input) to the parent li element, so the handleComplete function is prevented from running.